### PR TITLE
feat: Copy LICENSE and NOTICE into runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM scratch AS license
+COPY LICENSE /LICENSE
+COPY NOTICE /NOTICE
+
 FROM busybox AS bin
 COPY ./dist /dist
 RUN if [[ "$(arch)" == "x86_64" ]]; then \
@@ -20,5 +24,7 @@ LABEL org.opencontainers.image.title="mealie-webhook-handler" \
       org.opencontainers.image.url="https://github.com/timo-reymann/mealie-webhook-handler" \
       org.opencontainers.image.documentation="https://github.com/timo-reymann/mealie-webhook-handler" \
       org.opencontainers.image.source="https://github.com/timo-reymann/mealie-webhook-handler.git"
+
+COPY --from=license / /
 
 COPY --from=bin /bin/mealie-webhook-handler /bin/mealie-webhook-handler


### PR DESCRIPTION
## Summary
- Adds a `scratch`-based `license` stage that bundles `LICENSE` and `NOTICE`
- Copies those files into the final runtime image via `COPY --from=license / /`

This mirrors the approach used in [ContainerHive's Dockerfile](https://github.com/ContainerHive/ContainerHive/blob/main/Dockerfile), ensuring the license and third-party attribution notices ship inside the published image.

## Test plan
- [x] `docker build` succeeds and `/LICENSE` + `/NOTICE` are present in the resulting image

🤖 Generated with [Claude Code](https://claude.com/claude-code)